### PR TITLE
Refactor emitter registry to use a class variable

### DIFF
--- a/lib/sql.rb
+++ b/lib/sql.rb
@@ -36,5 +36,5 @@ require 'sql/parser'
 require 'sql/version'
 require 'sql/node_helper'
 
-# Freeze the registry once it is setup
-SQL::Generator::Emitter.registry.finalize
+# Finalize the emitter dispatch table
+SQL::Generator::Emitter.finalize

--- a/lib/sql/generator/emitter.rb
+++ b/lib/sql/generator/emitter.rb
@@ -24,7 +24,7 @@ module SQL
 
       # Emit node into buffer
       #
-      # @return [self]
+      # @return [Class<Emitter>]
       #
       # @api private
       #
@@ -68,7 +68,7 @@ module SQL
       # @param [Parser::AST::Node] node
       # @param [Buffer] buffer
       #
-      # @return [Emitter]
+      # @return [Class<Emitter>]
       #
       # @api private
       #

--- a/lib/sql/generator/emitter.rb
+++ b/lib/sql/generator/emitter.rb
@@ -7,20 +7,7 @@ module SQL
     class Emitter
       include Adamantium::Flat, AbstractType, Constants
 
-      class << self
-
-        # Accessor for registry
-        #
-        # @return [Registry]
-        #
-        # @api private
-        attr_accessor :registry
-
-      end
-
-      private_class_method :registry=
-
-      self.registry = Registry.new
+      @@registry = Registry.new
 
       # Emit node into buffer
       #
@@ -43,7 +30,7 @@ module SQL
       #
       def self.handle(*types)
         types.each do |type|
-          Emitter.registry[type] = self
+          @@registry[type] = self
         end
       end
       private_class_method :handle
@@ -73,7 +60,16 @@ module SQL
       # @api private
       #
       def self.visit(node, buffer)
-        Emitter.registry[node.type].emit(node, buffer)
+        @@registry[node.type].emit(node, buffer)
+        self
+      end
+
+      # @return [Class<Emitter>]
+      #
+      # @api private
+      #
+      def self.finalize
+        @@registry.finalize
         self
       end
 


### PR DESCRIPTION
@solnic wdyt?

Normally I wouldn't use class variables for much, except this is precisely the use case they were designed for (share state between classes in the same hierarchy).

Also, I wanted to hide the fact there is a registry from the public interface, and added an Emitter.finalize method that is responsible for finalizing the registry.
