### PR TITLE
Rename nodes to use ANSI SQL spec names

### DIFF
--- a/lib/sql/generator/emitter/literal/integer.rb
+++ b/lib/sql/generator/emitter/literal/integer.rb
@@ -8,7 +8,7 @@ module SQL
         # Literal integer emitter
         class Integer < self
 
-          handle :int
+          handle :integer
 
         private
 

--- a/lib/sql/generator/emitter/literal/string.rb
+++ b/lib/sql/generator/emitter/literal/string.rb
@@ -8,7 +8,7 @@ module SQL
         # Literal string emitter
         class String < self
 
-          handle :str
+          handle :string
 
         private
 

--- a/spec/unit/sql/generator/emitter/class_methods/visit_spec.rb
+++ b/spec/unit/sql/generator/emitter/class_methods/visit_spec.rb
@@ -16,7 +16,7 @@ describe SQL::Generator::Emitter, '.visit' do
   end
 
   context 'with integers' do
-    assert_generates s(:int, 1), '1'
+    assert_generates s(:integer, 1), '1'
   end
 
   context 'with floats' do
@@ -25,11 +25,11 @@ describe SQL::Generator::Emitter, '.visit' do
 
   context 'unary scalars' do
     context 'with unary plus' do
-      assert_generates s(:uplus, s(:int, 1)), '+(1)'
+      assert_generates s(:uplus, s(:integer, 1)), '+(1)'
     end
 
     context 'with unary minus' do
-      assert_generates s(:uminus, s(:int, 1)), '-(1)'
+      assert_generates s(:uminus, s(:integer, 1)), '-(1)'
     end
 
     context 'with unary negation' do
@@ -62,7 +62,7 @@ describe SQL::Generator::Emitter, '.visit' do
         :div => '/',
         :mod => '%'
       }.each do |type, operator|
-        assert_generates s(type, s(:int, 1), s(:int, 1)), "(1) #{operator} (1)"
+        assert_generates s(type, s(:integer, 1), s(:integer, 1)), "(1) #{operator} (1)"
       end
     end
   end

--- a/spec/unit/sql/generator/emitter/class_methods/visit_spec.rb
+++ b/spec/unit/sql/generator/emitter/class_methods/visit_spec.rb
@@ -12,7 +12,7 @@ describe SQL::Generator::Emitter, '.visit' do
   end
 
   context 'with strings' do
-    assert_generates s(:str, %q(echo 'Hello')), %q('echo ''Hello''')
+    assert_generates s(:string, %q(echo 'Hello')), %q('echo ''Hello''')
   end
 
   context 'with integers' do
@@ -47,7 +47,7 @@ describe SQL::Generator::Emitter, '.visit' do
     end
 
     context ':concat' do
-      assert_generates s(:concat, s(:str, 'foo'), s(:str, 'bar')), %q[('foo') || ('bar')]
+      assert_generates s(:concat, s(:string, 'foo'), s(:string, 'bar')), %q[('foo') || ('bar')]
     end
 
     context ':or' do


### PR DESCRIPTION
This branch will rename the existing nodes to use the same names as in the ANSI 92 SQL spec.
- [x] Rename `:int` to `:integer`.
- [x] Rename `:str` to `:string`.
- [x] Ready for review.
