### PR TITLE
Replace delimited

### DIFF
--- a/lib/sql/generator/emitter/delimited.rb
+++ b/lib/sql/generator/emitter/delimited.rb
@@ -6,7 +6,7 @@ module SQL
 
       # Delimited names emitter
       class Delimited < self
-        handle :delimited
+        handle :set, :fields, :where, :group_by
 
       private
 

--- a/lib/sql/generator/emitter/select.rb
+++ b/lib/sql/generator/emitter/select.rb
@@ -8,7 +8,7 @@ module SQL
       class Select < self
         handle :select
 
-        children :fields, :identifier, :where, :group_by
+        children :fields, :from, :where, :group_by
 
       private
 
@@ -21,7 +21,7 @@ module SQL
           write(K_SELECT, WS)
           visit(fields)
           write(WS, K_FROM, WS)
-          visit(identifier)
+          visit(from)
           write_node(where, K_WHERE)
           write_node(group_by, K_GROUP_BY)
         end

--- a/lib/sql/generator/emitter/select.rb
+++ b/lib/sql/generator/emitter/select.rb
@@ -8,7 +8,7 @@ module SQL
       class Select < self
         handle :select
 
-        children :columns, :identifier, :where, :group_by
+        children :fields, :identifier, :where, :group_by
 
       private
 
@@ -19,7 +19,7 @@ module SQL
         # @api private
         def dispatch
           write(K_SELECT, WS)
-          visit(columns)
+          visit(fields)
           write(WS, K_FROM, WS)
           visit(identifier)
           write_node(where, K_WHERE)

--- a/spec/unit/sql/generator/emitter/class_methods/visit_spec.rb
+++ b/spec/unit/sql/generator/emitter/class_methods/visit_spec.rb
@@ -161,7 +161,7 @@ describe SQL::Generator::Emitter, '.visit' do
       assert_generates(
         s(:delete,
           s(:id, 'users'),
-          s(:delimited,
+          s(:where,
             s(:eq, s(:id, 'name'), s(:string, 'foo'))
           )
         ),
@@ -175,7 +175,7 @@ describe SQL::Generator::Emitter, '.visit' do
       assert_generates(
         s(:update,
           s(:id, 'users'),
-          s(:delimited,
+          s(:where,
             s(:eq, s(:id, 'name'), s(:string, 'foo')),
             s(:eq, s(:id, 'age'), s(:integer, 1))
           )
@@ -188,11 +188,11 @@ describe SQL::Generator::Emitter, '.visit' do
       assert_generates(
         s(:update,
           s(:id, 'users'),
-          s(:delimited,
+          s(:set,
             s(:eq, s(:id, 'name'), s(:string, 'foo')),
             s(:eq, s(:id, 'age'), s(:integer, 1))
           ),
-          s(:delimited,
+          s(:where,
             s(:eq, s(:id, 'age'), s(:integer, 2))
           )
         ),
@@ -209,7 +209,7 @@ describe SQL::Generator::Emitter, '.visit' do
     context 'without where clause' do
       assert_generates(
         s(:select,
-          s(:delimited, s(:id, 'name'), s(:id, 'age')), s(:id, 'users')
+          s(:fields, s(:id, 'name'), s(:id, 'age')), s(:id, 'users')
         ),
         %q[SELECT "name", "age" FROM "users"]
       )
@@ -218,11 +218,11 @@ describe SQL::Generator::Emitter, '.visit' do
     context 'with where clause' do
       assert_generates(
         s(:select,
-          s(:delimited,
+          s(:fields,
             s(:id, 'name'), s(:id, 'age')
           ),
           s(:id, 'users'),
-          s(:delimited,
+          s(:where,
             s(:eq, s(:id, 'id'), s(:integer, 1))
           )
         ),
@@ -233,10 +233,10 @@ describe SQL::Generator::Emitter, '.visit' do
     context 'with group by' do
       assert_generates(
         s(:select,
-          s(:delimited, s(:id, 'name'), s(:id, 'age')),
+          s(:fields, s(:id, 'name'), s(:id, 'age')),
           s(:id, 'users'),
           nil,
-          s(:delimited, s(:id, 'name'), s(:id, 'age'))
+          s(:where, s(:id, 'name'), s(:id, 'age'))
         ),
         <<-SQL.gsub(/\s+/, ' ').strip
           SELECT "name", "age"
@@ -249,10 +249,10 @@ describe SQL::Generator::Emitter, '.visit' do
     context 'with where and group by' do
       assert_generates(
         s(:select,
-          s(:delimited, s(:id, 'name'), s(:id, 'age')),
+          s(:fields, s(:id, 'name'), s(:id, 'age')),
           s(:id, 'users'),
-          s(:delimited, s(:eq, s(:id, 'id'), s(:integer, 1))),
-          s(:delimited, s(:id, 'name'), s(:id, 'age'))
+          s(:where, s(:eq, s(:id, 'id'), s(:integer, 1))),
+          s(:group_by, s(:id, 'name'), s(:id, 'age'))
         ),
         <<-SQL.gsub(/\s+/, ' ').strip
           SELECT "name", "age"
@@ -273,9 +273,9 @@ describe SQL::Generator::Emitter, '.visit' do
       context type.inspect do
         assert_generates(
           s(type,
-            s(:select, s(:delimited, s(:id, 'name')), s(:id, 'users')),
-            s(:select, s(:delimited, s(:id, 'name')), s(:id, 'customers')),
-            s(:select, s(:delimited, s(:id, 'name')), s(:id, 'employees')),
+            s(:select, s(:fields, s(:id, 'name')), s(:id, 'users')),
+            s(:select, s(:fields, s(:id, 'name')), s(:id, 'customers')),
+            s(:select, s(:fields, s(:id, 'name')), s(:id, 'employees')),
           ),
           <<-SQL.gsub(/\s+/, ' ').strip
             (SELECT "name" FROM "users")


### PR DESCRIPTION
This branch changes the s-expressions to use names that are better at describing the node that "delimited".
